### PR TITLE
feat: map props selected to component

### DIFF
--- a/src/components/Col/Col.js
+++ b/src/components/Col/Col.js
@@ -4,7 +4,9 @@ import styled from 'styled-components';
 import { themeProvider } from '~/theme';
 import { filterProps, mediaQuery, columnWidth, gutter, CSSProperty } from '~/helpers';
 
-const Col = styled(props => React.createElement(props.elementType, filterProps(props, Col.PropTypes)))`
+const Col = styled(props =>
+  React.createElement(props.elementType, filterProps(props, Col.PropTypes)),
+)`
   // Initial component properties
   box-sizing: border-box;
   flex: 0 0 auto;

--- a/src/components/Col/Col.js
+++ b/src/components/Col/Col.js
@@ -1,10 +1,10 @@
-import { PropTypes } from 'react';
+import React, { PropTypes } from 'react';
 import styled from 'styled-components';
 
 import { themeProvider } from '~/theme';
 import { mediaQuery, columnWidth, gutter, CSSProperty } from '~/helpers';
 
-const Col = styled.div`
+const Col = styled(props => React.createElement(props.elementType, props))`
   // Initial component properties
   box-sizing: border-box;
   flex: 0 0 auto;
@@ -26,6 +26,7 @@ const Col = styled.div`
 Col.defaultProps = {
   order: 0,
   alignSelf: 'auto',
+  elementType: 'div',
 };
 
 const alignSelfOptions = ['auto', 'flex-start', 'flex-end', 'center', 'baseline', 'stretch'];
@@ -78,6 +79,10 @@ Col.PropTypes = {
       lg: PropTypes.oneOf(alignSelfOptions),
     }),
   ]),
+
+  elementType: 'div',
+
+  children: PropTypes.node,
 };
 
 Col.displayName = 'Col';

--- a/src/components/Col/Col.js
+++ b/src/components/Col/Col.js
@@ -2,9 +2,9 @@ import React, { PropTypes } from 'react';
 import styled from 'styled-components';
 
 import { themeProvider } from '~/theme';
-import { mediaQuery, columnWidth, gutter, CSSProperty } from '~/helpers';
+import { filterProps, mediaQuery, columnWidth, gutter, CSSProperty } from '~/helpers';
 
-const Col = styled(props => React.createElement(props.elementType, props))`
+const Col = styled(props => React.createElement(props.elementType, filterProps(props, Col.PropTypes)))`
   // Initial component properties
   box-sizing: border-box;
   flex: 0 0 auto;

--- a/src/components/Col/Col.spec.js
+++ b/src/components/Col/Col.spec.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import Col from './Col';
+
+describe('Create element', () => {
+  test('Should by default create a div element', () => {
+    const wrapper = shallow(<Col />);
+    expect(wrapper.dive().type()).toEqual('div');
+  });
+
+  test('Should create a custom element if provided', () => {
+    const wrapper = shallow(<Col elementType="span" />);
+    expect(wrapper.dive().type()).toEqual('span');
+    expect(wrapper.dive().type()).not.toEqual('div');
+  });
+});

--- a/src/components/Row/Row.js
+++ b/src/components/Row/Row.js
@@ -1,10 +1,10 @@
-import { PropTypes } from 'react';
+import React, { PropTypes } from 'react';
 import styled from 'styled-components';
 
 import { themeProvider } from '~/theme';
 import { mediaQuery, gutter, CSSProperty } from '~/helpers';
 
-const Row = styled.div`
+const Row = styled(props => React.createElement(props.elementType || 'div', props))`
   // Initial component property
   box-sizing: border-box;
 
@@ -29,6 +29,7 @@ Row.defaultProps = {
   justifyContent: 'flex-start',
   alignItems: 'flex-start',
   alignContent: 'flex-start',
+  elementType: 'div',
 };
 
 const displayOptions = ['flex', 'flex-inline'];
@@ -110,6 +111,10 @@ Row.PropTypes = {
       lg: PropTypes.oneOf(alignContentOptions),
     }),
   ]),
+
+  elementType: PropTypes.string,
+
+  children: PropTypes.node,
 };
 
 Row.displayName = 'Row';

--- a/src/components/Row/Row.js
+++ b/src/components/Row/Row.js
@@ -2,9 +2,9 @@ import React, { PropTypes } from 'react';
 import styled from 'styled-components';
 
 import { themeProvider } from '~/theme';
-import { mediaQuery, gutter, CSSProperty } from '~/helpers';
+import { filterProps, mediaQuery, gutter, CSSProperty } from '~/helpers';
 
-const Row = styled(props => React.createElement(props.elementType || 'div', props))`
+const Row = styled(props => React.createElement(props.elementType, filterProps(props, Row.PropTypes))`
   // Initial component property
   box-sizing: border-box;
 

--- a/src/components/Row/Row.js
+++ b/src/components/Row/Row.js
@@ -4,7 +4,9 @@ import styled from 'styled-components';
 import { themeProvider } from '~/theme';
 import { filterProps, mediaQuery, gutter, CSSProperty } from '~/helpers';
 
-const Row = styled(props => React.createElement(props.elementType, filterProps(props, Row.PropTypes))`
+const Row = styled(props =>
+  React.createElement(props.elementType, filterProps(props, Row.PropTypes)),
+)`
   // Initial component property
   box-sizing: border-box;
 

--- a/src/components/Row/Row.spec.js
+++ b/src/components/Row/Row.spec.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import Row from './Row';
+
+describe('Create element', () => {
+  test('Should by default create a div element', () => {
+    const wrapper = shallow(<Row />);
+    expect(wrapper.dive().type()).toEqual('div');
+  });
+
+  test('Should create a custom element if provided', () => {
+    const wrapper = shallow(<Row elementType="span" />);
+    expect(wrapper.dive().type()).toEqual('span');
+    expect(wrapper.dive().type()).not.toEqual('div');
+  });
+});

--- a/src/helpers/filterProps/filterProps.js
+++ b/src/helpers/filterProps/filterProps.js
@@ -1,0 +1,10 @@
+import _ from 'lodash';
+
+const safeProps = ['children'];
+
+const filterProps = (props, filterOut) =>
+  _.omitBy(props, (value, key) =>
+    _.has(filterOut, `${key}`) && !_.includes(safeProps, key),
+  );
+
+export default filterProps;

--- a/src/helpers/filterProps/filterProps.spec.js
+++ b/src/helpers/filterProps/filterProps.spec.js
@@ -1,0 +1,22 @@
+import filterProps from './filterProps';
+
+test('should filter props from supplied object', () => {
+  const mockProps = { xs: -1, sm: 2, md: 0, lg: 6 };
+  const propsToRemove = { xs: '', display: '' };
+
+  expect(filterProps(mockProps, propsToRemove)).toEqual({ sm: 2, md: 0, lg: 6 });
+});
+
+test('should ignore nested objects in second argument, propsToRemove', () => {
+  const mockProps = { xs: -1, sm: 2, md: 0, lg: 6 };
+  const propsToRemove = { xs: 'foo', display: 'sm' };
+
+  expect(filterProps(mockProps, propsToRemove)).toEqual({ sm: 2, md: 0, lg: 6 });
+});
+
+test('should not filter out safe props such as children', () => {
+  const mockProps = { xs: -1, sm: 2, md: 0, lg: 6, children: { foo: 'bar' } };
+  const propsToRemove = { xs: 'foo', display: 'bar', children: 'baz' };
+
+  expect(filterProps(mockProps, propsToRemove)).toEqual({ sm: 2, md: 0, lg: 6, children: { foo: 'bar' } });
+});

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -1,5 +1,6 @@
 export columnWidth from './columnWidth/columnWidth';
 export CSSProperty from './CSSProperty/CSSProperty';
+export filterProps from './filterProps/filterProps';
 export * as gutter from './gutter/gutter';
 export mediaQuery from './mediaQuery/mediaQuery';
 export sortBreakpoints from './sortBreakpoints/sortBreakpoints';


### PR DESCRIPTION
- Enabled props such as children and className to still be mapped across to the Col and Row component. 
- Added helper function to remove props from the component during creation