### PR TITLE
Simplify eslint config

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,15 +2,10 @@
   "extends": "airbnb",
   "parser": "babel-eslint",
   "env": {
-    "browser": true,
-    "jest": true,
-    "node": true,
+    "jest": true
   },
   "rules": {
-    "import/no-extraneous-dependencies": 0,
     "import/prefer-default-export": 0,
-    "import/no-unresolved": [2, { "ignore": ["^[~@]"] }],
-    "react/jsx-filename-extension": 0,
-    "import/extensions": ["off", "never"],
+    "react/jsx-filename-extension": 0
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,12 +39,12 @@
     "jest": "^19.0.2",
     "jsdom": "^9.12.0",
     "jsdom-global": "^2.1.1",
-    "lodash": "^4.17.4",
     "react-addons-test-utils": "^15.4.2"
   },
   "dependencies": {
-    "react": "^15.4.2",
+    "lodash": "^4.17.4",
     "react-dom": "^15.4.2",
+    "react": "^15.4.2",
     "styled-components": "^1.4.4"
   }
 }


### PR DESCRIPTION
- Remove unnecessary rules
- Remove envs that are already declared by airbnb config
- Move lodash to dependencies (it was mistakenly added as a dev dependency)