### PR TITLE
fix: Themed breakpoint not being applied

### DIFF
--- a/src/components/Col/Col.js
+++ b/src/components/Col/Col.js
@@ -13,9 +13,7 @@ const Col = styled(props =>
   flex: 0 0 auto;
   display: block;
 
-  ${props =>
-    themeProvider.breakpointsKeys(props).map(breakpoint =>
-      mediaQuery(themeProvider.currentBreakpointValue(props, breakpoint), `
+  ${props => themeProvider.breakpointsKeys(props).map(breakpoint => mediaQuery(props)`
     // Generate gutter
     ${gutter.col(props, breakpoint)}
 
@@ -25,7 +23,7 @@ const Col = styled(props =>
     // Responsive Flexbox properties
     ${CSSProperty(props, breakpoint, 'order')}
     ${CSSProperty(props, breakpoint, 'align-self')}
-  `))};
+  `)};
 `;
 
 Col.defaultProps = {

--- a/src/components/Col/Col.js
+++ b/src/components/Col/Col.js
@@ -13,7 +13,7 @@ const Col = styled(props =>
   flex: 0 0 auto;
   display: block;
 
-  ${props => themeProvider.breakpointsKeys(props).map(breakpoint => mediaQuery(props)`
+  ${props => themeProvider.breakpointsKeys(props).map(breakpoint => mediaQuery(props)[breakpoint]`
     // Generate gutter
     ${gutter.col(props, breakpoint)}
 

--- a/src/components/Col/Col.js
+++ b/src/components/Col/Col.js
@@ -13,7 +13,9 @@ const Col = styled(props =>
   flex: 0 0 auto;
   display: block;
 
-  ${props => themeProvider.breakpoints.map(breakpoint => mediaQuery[breakpoint]`
+  ${props =>
+    themeProvider.breakpointsKeys(props).map(breakpoint =>
+      mediaQuery(themeProvider.currentBreakpointValue(props, breakpoint), `
     // Generate gutter
     ${gutter.col(props, breakpoint)}
 
@@ -23,7 +25,7 @@ const Col = styled(props =>
     // Responsive Flexbox properties
     ${CSSProperty(props, breakpoint, 'order')}
     ${CSSProperty(props, breakpoint, 'align-self')}
-  `)};
+  `))};
 `;
 
 Col.defaultProps = {

--- a/src/components/Col/__snapshots__/Col.spec.js.snap
+++ b/src/components/Col/__snapshots__/Col.spec.js.snap
@@ -8,12 +8,12 @@ exports[`style rendering renders corrects 1`] = `
 >
   <Component
     alignSelf="auto"
-    className="sc-bdVaJa kXNDzH"
+    className="sc-bdVaJa eDhNEW"
     elementType="div"
     order={0}
   >
     <div
-      className="sc-bdVaJa kXNDzH"
+      className="sc-bdVaJa eDhNEW"
     />
   </Component>
 </Col>

--- a/src/components/Col/__snapshots__/Col.spec.js.snap
+++ b/src/components/Col/__snapshots__/Col.spec.js.snap
@@ -8,12 +8,12 @@ exports[`style rendering renders corrects 1`] = `
 >
   <Component
     alignSelf="auto"
-    className="sc-bdVaJa eDhNEW"
+    className="sc-bdVaJa jURNTC"
     elementType="div"
     order={0}
   >
     <div
-      className="sc-bdVaJa eDhNEW"
+      className="sc-bdVaJa jURNTC"
     />
   </Component>
 </Col>

--- a/src/components/Row/Row.js
+++ b/src/components/Row/Row.js
@@ -11,7 +11,9 @@ const Row = styled(props =>
   // Initial component property
   box-sizing: border-box;
 
-  ${props => themeProvider.breakpoints.map(breakpoint => mediaQuery[breakpoint]`
+  ${props =>
+    themeProvider.breakpointsKeys(props).map(breakpoint =>
+      mediaQuery(themeProvider.currentBreakpointValue(props, breakpoint), `
     // Generate gutter
     ${gutter.row(props, breakpoint)}
 
@@ -22,7 +24,7 @@ const Row = styled(props =>
     ${CSSProperty(props, breakpoint, 'justify-content')}
     ${CSSProperty(props, breakpoint, 'align-items')}
     ${CSSProperty(props, breakpoint, 'align-content')}
-  `)};
+  `))};
 `;
 
 Row.defaultProps = {

--- a/src/components/Row/Row.js
+++ b/src/components/Row/Row.js
@@ -11,7 +11,7 @@ const Row = styled(props =>
   // Initial component property
   box-sizing: border-box;
 
-  ${props => themeProvider.breakpointsKeys(props).map(breakpoint => mediaQuery(props)`
+  ${props => themeProvider.breakpointsKeys(props).map(breakpoint => mediaQuery(props)[breakpoint]`
     // Generate gutter
     ${gutter.row(props, breakpoint)}
 

--- a/src/components/Row/Row.js
+++ b/src/components/Row/Row.js
@@ -11,9 +11,7 @@ const Row = styled(props =>
   // Initial component property
   box-sizing: border-box;
 
-  ${props =>
-    themeProvider.breakpointsKeys(props).map(breakpoint =>
-      mediaQuery(themeProvider.currentBreakpointValue(props, breakpoint), `
+  ${props => themeProvider.breakpointsKeys(props).map(breakpoint => mediaQuery(props)`
     // Generate gutter
     ${gutter.row(props, breakpoint)}
 
@@ -24,7 +22,7 @@ const Row = styled(props =>
     ${CSSProperty(props, breakpoint, 'justify-content')}
     ${CSSProperty(props, breakpoint, 'align-items')}
     ${CSSProperty(props, breakpoint, 'align-content')}
-  `))};
+  `)};
 `;
 
 Row.defaultProps = {

--- a/src/components/Row/__snapshots__/Row.spec.js.snap
+++ b/src/components/Row/__snapshots__/Row.spec.js.snap
@@ -13,7 +13,7 @@ exports[`style rendering renders corrects 1`] = `
   <Component
     alignContent="flex-start"
     alignItems="flex-start"
-    className="sc-bdVaJa jgdJrf"
+    className="sc-bdVaJa jjShM"
     display="flex"
     elementType="div"
     flexDirection="row"
@@ -21,7 +21,7 @@ exports[`style rendering renders corrects 1`] = `
     justifyContent="flex-start"
   >
     <div
-      className="sc-bdVaJa jgdJrf"
+      className="sc-bdVaJa jjShM"
     />
   </Component>
 </Row>

--- a/src/components/Row/__snapshots__/Row.spec.js.snap
+++ b/src/components/Row/__snapshots__/Row.spec.js.snap
@@ -13,7 +13,7 @@ exports[`style rendering renders corrects 1`] = `
   <Component
     alignContent="flex-start"
     alignItems="flex-start"
-    className="sc-bdVaJa jjShM"
+    className="sc-bdVaJa hXfgcI"
     display="flex"
     elementType="div"
     flexDirection="row"
@@ -21,7 +21,7 @@ exports[`style rendering renders corrects 1`] = `
     justifyContent="flex-start"
   >
     <div
-      className="sc-bdVaJa jjShM"
+      className="sc-bdVaJa hXfgcI"
     />
   </Component>
 </Row>

--- a/src/helpers/mediaQuery/mediaQuery.js
+++ b/src/helpers/mediaQuery/mediaQuery.js
@@ -4,18 +4,20 @@ import { themeProvider } from '../../theme';
 
 const { theme } = themeProvider;
 
-const mediaQuery = Object.keys(theme().breakpoints).reduce((accumulator, value) => {
-  const breakpointSize = theme().breakpoints[value];
+const mediaQuery = props =>
+  (Object.keys(theme(props).breakpoints).reduce((accumulator, value) => {
+    const breakpointSize = theme(props).breakpoints[value];
 
-  Object.assign(accumulator, { [value]: (...args) =>
-    (breakpointSize === 0 ? css`${css(...args)}` :
-      css`@media (min-width: ${breakpointSize}rem) {
-        ${css(...args)}
-      }`
-    ),
-  });
+    Object.assign(accumulator, { [value]: (...args) =>
+      (breakpointSize === 0 ? css`${css(...args)}` :
+        css`@media (min-width: ${breakpointSize}rem) {
+          ${css(...args)}
+        }`
+      ),
+    });
 
-  return accumulator;
-}, {});
+    return accumulator;
+  }, {})
+);
 
 export default mediaQuery;

--- a/src/helpers/mediaQuery/mediaQuery.js
+++ b/src/helpers/mediaQuery/mediaQuery.js
@@ -1,21 +1,10 @@
 import { css } from 'styled-components';
 
-import { themeProvider } from '../../theme';
-
-const { theme } = themeProvider;
-
-const mediaQuery = Object.keys(theme().breakpoints).reduce((accumulator, value) => {
-  const breakpointSize = theme().breakpoints[value];
-
-  Object.assign(accumulator, { [value]: (...args) =>
-    (breakpointSize === 0 ? css`${css(...args)}` :
-      css`@media (min-width: ${breakpointSize}rem) {
-        ${css(...args)}
-      }`
-    ),
-  });
-
-  return accumulator;
-}, {});
+const mediaQuery = (width, styles) => (
+  (width === 0) ? css`${styles.split(',').join('')}` :
+  css`@media (min-width: ${width}rem) {
+    ${styles.split(',').join('')}
+  }`
+);
 
 export default mediaQuery;

--- a/src/helpers/mediaQuery/mediaQuery.js
+++ b/src/helpers/mediaQuery/mediaQuery.js
@@ -5,7 +5,7 @@ import { themeProvider } from '../../theme';
 const { theme } = themeProvider;
 
 const mediaQuery = props =>
-  (Object.keys(theme(props).breakpoints).reduce((accumulator, value) => {
+  (themeProvider.breakpointsKeys(props).reduce((accumulator, value) => {
     const breakpointSize = theme(props).breakpoints[value];
 
     Object.assign(accumulator, { [value]: (...args) =>

--- a/src/helpers/mediaQuery/mediaQuery.js
+++ b/src/helpers/mediaQuery/mediaQuery.js
@@ -1,10 +1,21 @@
 import { css } from 'styled-components';
 
-const mediaQuery = (width, styles) => (
-  (width === 0) ? css`${styles.split(',').join('')}` :
-  css`@media (min-width: ${width}rem) {
-    ${styles.split(',').join('')}
-  }`
-);
+import { themeProvider } from '../../theme';
+
+const { theme } = themeProvider;
+
+const mediaQuery = Object.keys(theme().breakpoints).reduce((accumulator, value) => {
+  const breakpointSize = theme().breakpoints[value];
+
+  Object.assign(accumulator, { [value]: (...args) =>
+    (breakpointSize === 0 ? css`${css(...args)}` :
+      css`@media (min-width: ${breakpointSize}rem) {
+        ${css(...args)}
+      }`
+    ),
+  });
+
+  return accumulator;
+}, {});
 
 export default mediaQuery;

--- a/src/helpers/mediaQuery/mediaQuery.spec.js
+++ b/src/helpers/mediaQuery/mediaQuery.spec.js
@@ -1,25 +1,25 @@
 import mediaQuery from './mediaQuery';
 
 test('should generate a media query for lg breakpoint', () => {
-  const query = (mediaQuery.lg`color: red`).join('');
+  const query = (mediaQuery().lg`color: red`).join('');
   expect(query).toContain('@media (min-width: 60rem)');
   expect(query).toContain('color: red');
 });
 
 test('should generate a media query for md breakpoint', () => {
-  const query = (mediaQuery.md`color: blue`).join('');
+  const query = (mediaQuery().md`color: blue`).join('');
   expect(query).toContain('@media (min-width: 48rem)');
   expect(query).toContain('color: blue');
 });
 
 test('should generate a media query for sm breakpoint', () => {
-  const query = (mediaQuery.sm`color: green`).join('');
+  const query = (mediaQuery().sm`color: green`).join('');
   expect(query).toContain('@media (min-width: 30rem)');
   expect(query).toContain('color: green');
 });
 
 test('should not generate a media query for xs breakpoint', () => {
-  const query = (mediaQuery.xs`color: yellow`).join('');
+  const query = (mediaQuery().xs`color: yellow`).join('');
   expect(query).not.toContain('@media (min-width: 0rem)');
   expect(query).toContain('color: yellow');
 });

--- a/src/helpers/mediaQuery/mediaQuery.spec.js
+++ b/src/helpers/mediaQuery/mediaQuery.spec.js
@@ -1,13 +1,25 @@
 import mediaQuery from './mediaQuery';
 
 test('should generate a media query for lg breakpoint', () => {
-  const query = (mediaQuery(60, 'color: red')).join('');
+  const query = (mediaQuery.lg`color: red`).join('');
   expect(query).toContain('@media (min-width: 60rem)');
   expect(query).toContain('color: red');
 });
 
+test('should generate a media query for md breakpoint', () => {
+  const query = (mediaQuery.md`color: blue`).join('');
+  expect(query).toContain('@media (min-width: 48rem)');
+  expect(query).toContain('color: blue');
+});
+
+test('should generate a media query for sm breakpoint', () => {
+  const query = (mediaQuery.sm`color: green`).join('');
+  expect(query).toContain('@media (min-width: 30rem)');
+  expect(query).toContain('color: green');
+});
+
 test('should not generate a media query for xs breakpoint', () => {
-  const query = (mediaQuery(0, 'color: yellow')).join('');
+  const query = (mediaQuery.xs`color: yellow`).join('');
   expect(query).not.toContain('@media (min-width: 0rem)');
   expect(query).toContain('color: yellow');
 });

--- a/src/helpers/mediaQuery/mediaQuery.spec.js
+++ b/src/helpers/mediaQuery/mediaQuery.spec.js
@@ -1,25 +1,13 @@
 import mediaQuery from './mediaQuery';
 
 test('should generate a media query for lg breakpoint', () => {
-  const query = (mediaQuery.lg`color: red`).join('');
+  const query = (mediaQuery(60, 'color: red')).join('');
   expect(query).toContain('@media (min-width: 60rem)');
   expect(query).toContain('color: red');
 });
 
-test('should generate a media query for md breakpoint', () => {
-  const query = (mediaQuery.md`color: blue`).join('');
-  expect(query).toContain('@media (min-width: 48rem)');
-  expect(query).toContain('color: blue');
-});
-
-test('should generate a media query for sm breakpoint', () => {
-  const query = (mediaQuery.sm`color: green`).join('');
-  expect(query).toContain('@media (min-width: 30rem)');
-  expect(query).toContain('color: green');
-});
-
 test('should not generate a media query for xs breakpoint', () => {
-  const query = (mediaQuery.xs`color: yellow`).join('');
+  const query = (mediaQuery(0, 'color: yellow')).join('');
   expect(query).not.toContain('@media (min-width: 0rem)');
   expect(query).toContain('color: yellow');
 });

--- a/src/theme/theme.js
+++ b/src/theme/theme.js
@@ -24,4 +24,3 @@ export const theme = (props) => {
 
 export const breakpoints = props => theme(props).breakpoints;
 export const breakpointsKeys = props => Object.keys(theme(props).breakpoints);
-export const currentBreakpointValue = (props, breakpoint) => breakpoints(props)[breakpoint];

--- a/src/theme/theme.js
+++ b/src/theme/theme.js
@@ -22,5 +22,6 @@ export const theme = (props) => {
   });
 };
 
-// TODO generate these dynamically based on the object keys for breakpoints
-export const breakpoints = ['xs', 'sm', 'md', 'lg'];
+export const breakpoints = props => theme(props).breakpoints;
+export const breakpointsKeys = props => Object.keys(theme(props).breakpoints);
+export const currentBreakpointValue = (props, breakpoint) => breakpoints(props)[breakpoint];

--- a/src/theme/theme.spec.js
+++ b/src/theme/theme.spec.js
@@ -1,11 +1,15 @@
 import { themeProvider, defaultTheme } from '../theme';
 
-const { theme, breakpoints } = themeProvider;
+const {
+  theme,
+  breakpoints,
+  breakpointsKeys,
+  currentBreakpointValue,
+} = themeProvider;
 
 
 test('should set the default theme if a custom theme is not provided', () => {
   expect(theme()).toEqual(defaultTheme);
-  expect(breakpoints).toEqual(Object.keys(defaultTheme.breakpoints));
 });
 
 describe('overriding the default theme', () => {
@@ -50,5 +54,76 @@ describe('overriding the default theme', () => {
 
     expect(theme(customTheme)).toEqual(customTheme.theme.flexa);
     expect(theme(customTheme)).not.toEqual(defaultTheme);
+  });
+});
+
+describe('breakpoint method', () => {
+  const customTheme = {
+    theme: { flexa: { breakpoints: { lg: 65, md: 55, sm: 45, xs: 35 } } },
+  };
+
+  test('should return breakpoints of custom theme', () => {
+    expect(breakpoints(customTheme)).toEqual(
+      { lg: 65, md: 55, sm: 45, xs: 35 },
+    );
+  });
+
+  test('should return custom breakpoints of custom theme with additional breakpoints', () => {
+    const customBreakpoints = {
+      theme: { flexa: { breakpoints: { lg: 65, md: 55, sm: 45, xs: 35, xl: 90, xxl: 120 } } },
+    };
+    expect(breakpoints(customBreakpoints)).toEqual(
+      { lg: 65, md: 55, sm: 45, xl: 90, xs: 35, xxl: 120 },
+    );
+  });
+
+  test('should return default breakpoints if no theme is provided', () => {
+    expect(breakpoints()).toEqual(defaultTheme.breakpoints);
+  });
+});
+
+describe('breakpointsKeys method', () => {
+  const customTheme = {
+    theme: { flexa: { breakpoints: { md: 55, lg: 65, xs: 35, sm: 45 } } },
+  };
+
+  test('should return breakpoints keys of custom theme', () => {
+    expect(breakpointsKeys(customTheme)).toEqual(['xs', 'sm', 'md', 'lg']);
+  });
+
+  test('should return custom breakpoints of custom theme with additional breakpoints', () => {
+    const customBreakpoints = {
+      theme: { flexa: { breakpoints: { lg: 65, md: 55, sm: 45, xs: 35, xl: 90, xxl: 120 } } },
+    };
+    expect(breakpointsKeys(customBreakpoints)).toEqual(
+      ['xs', 'sm', 'md', 'lg', 'xl', 'xxl'],
+    );
+  });
+
+  test('should return default breakpoints if no theme is provided', () => {
+    expect(breakpointsKeys()).toEqual(Object.keys(defaultTheme.breakpoints));
+  });
+});
+
+describe('currentBreakpointValue method', () => {
+  const customTheme = {
+    theme: { flexa: { breakpoints: { md: 55, lg: 65, xs: 35, sm: 45 } } },
+  };
+
+  test('should return breakpoint with custom theme', () => {
+    expect(currentBreakpointValue(customTheme, 'sm')).toEqual(45);
+  });
+
+  test('should return custom breakpoint of custom theme with additional breakpoints', () => {
+    const customBreakpoints = {
+      theme: { flexa: { breakpoints: { lg: 65, md: 55, sm: 45, xs: 35, xl: 90, xxl: 120 } } },
+    };
+    expect(currentBreakpointValue(customBreakpoints, 'xl')).toEqual(90);
+  });
+
+  test('should return default breakpoint if no theme is provided', () => {
+    expect(currentBreakpointValue({}, 'sm')).toEqual(30);
+    expect(currentBreakpointValue(undefined, 'sm')).toEqual(30);
+    expect(currentBreakpointValue(null, 'sm')).toEqual(30);
   });
 });

--- a/src/theme/theme.spec.js
+++ b/src/theme/theme.spec.js
@@ -4,7 +4,6 @@ const {
   theme,
   breakpoints,
   breakpointsKeys,
-  currentBreakpointValue,
 } = themeProvider;
 
 
@@ -102,28 +101,5 @@ describe('breakpointsKeys method', () => {
 
   test('should return default breakpoints if no theme is provided', () => {
     expect(breakpointsKeys()).toEqual(Object.keys(defaultTheme.breakpoints));
-  });
-});
-
-describe('currentBreakpointValue method', () => {
-  const customTheme = {
-    theme: { flexa: { breakpoints: { md: 55, lg: 65, xs: 35, sm: 45 } } },
-  };
-
-  test('should return breakpoint with custom theme', () => {
-    expect(currentBreakpointValue(customTheme, 'sm')).toEqual(45);
-  });
-
-  test('should return custom breakpoint of custom theme with additional breakpoints', () => {
-    const customBreakpoints = {
-      theme: { flexa: { breakpoints: { lg: 65, md: 55, sm: 45, xs: 35, xl: 90, xxl: 120 } } },
-    };
-    expect(currentBreakpointValue(customBreakpoints, 'xl')).toEqual(90);
-  });
-
-  test('should return default breakpoint if no theme is provided', () => {
-    expect(currentBreakpointValue({}, 'sm')).toEqual(30);
-    expect(currentBreakpointValue(undefined, 'sm')).toEqual(30);
-    expect(currentBreakpointValue(null, 'sm')).toEqual(30);
   });
 });


### PR DESCRIPTION
Fixes: #61 

Properly includes the breakpoint value when creating the media queries. 

# Help wanted: 

Currently, with the way I am passing the template string as the second argument it now includes commas separating the string and the values, I'm having to now split on comma and rejoin. this is a very hacky solution. 