### PR TITLE
Don't use modular lodash packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,16 +64,7 @@
     "styled-components": "^2.0.0"
   },
   "dependencies": {
-    "lodash.camelcase": "^4.3.0",
-    "lodash.has": "^4.5.2",
-    "lodash.includes": "^4.3.0",
-    "lodash.isnull": "^3.0.0",
-    "lodash.isnumber": "^3.0.3",
-    "lodash.isobject": "^3.0.2",
-    "lodash.isundefined": "^3.0.1",
-    "lodash.map": "^4.6.0",
-    "lodash.omitby": "^4.6.0",
-    "lodash.sortby": "^4.7.0",
+    "lodash": "^4.17.4",
     "prop-types": "^15.5.10"
   }
 }

--- a/src/helpers/CSSProperty/CSSProperty.js
+++ b/src/helpers/CSSProperty/CSSProperty.js
@@ -1,7 +1,7 @@
-import has from 'lodash.has';
-import camelCase from 'lodash.camelcase';
-import isObject from 'lodash.isobject';
-import isNull from 'lodash.isnull';
+import has from 'lodash/has';
+import camelCase from 'lodash/camelCase';
+import isObject from 'lodash/isObject';
+import isNull from 'lodash/isNull';
 import { css } from 'styled-components';
 
 import { themeProvider } from '../../theme';

--- a/src/helpers/columnWidth/columnWidth.js
+++ b/src/helpers/columnWidth/columnWidth.js
@@ -1,5 +1,5 @@
 import { css } from 'styled-components';
-import has from 'lodash.has';
+import has from 'lodash/has';
 
 import { themeProvider } from '../../theme';
 

--- a/src/helpers/filterProps/filterProps.js
+++ b/src/helpers/filterProps/filterProps.js
@@ -1,6 +1,6 @@
-import omitBy from 'lodash.omitby';
-import has from 'lodash.has';
-import includes from 'lodash.includes';
+import omitBy from 'lodash/omitBy';
+import has from 'lodash/has';
+import includes from 'lodash/includes';
 
 const safeProps = ['children'];
 

--- a/src/helpers/gutter/gutter.js
+++ b/src/helpers/gutter/gutter.js
@@ -1,7 +1,7 @@
-import has from 'lodash.has';
-import isObject from 'lodash.isobject';
-import isNumber from 'lodash.isnumber';
-import isUndefined from 'lodash.isundefined';
+import has from 'lodash/has';
+import isObject from 'lodash/isObject';
+import isNumber from 'lodash/isNumber';
+import isUndefined from 'lodash/isUndefined';
 import { css } from 'styled-components';
 
 import { themeProvider } from '../../theme';

--- a/src/helpers/sortBreakpoints/sortBreakpoints.js
+++ b/src/helpers/sortBreakpoints/sortBreakpoints.js
@@ -1,5 +1,5 @@
-import map from 'lodash.map';
-import sortBy from 'lodash.sortby';
+import map from 'lodash/map';
+import sortBy from 'lodash/sortBy';
 
 const sortBreakpoints = (breakpoints) => {
   const mappedBreakpoints = map(breakpoints, (value, key) => ({ key, value }));

--- a/src/theme/theme.js
+++ b/src/theme/theme.js
@@ -1,4 +1,4 @@
-import has from 'lodash.has';
+import has from 'lodash/has';
 
 import { FLEXA_THEME } from '../config';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3973,14 +3973,6 @@ lodash.foreach@^4.3.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
 
-lodash.has@^4.5.2:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/lodash.has/-/lodash.has-4.5.2.tgz#d19f4dc1095058cccbe2b0cdf4ee0fe4aa37c862"
-
-lodash.includes@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
-
 lodash.isarguments@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
@@ -3993,25 +3985,9 @@ lodash.isnil@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/lodash.isnil/-/lodash.isnil-4.0.0.tgz#49e28cd559013458c814c5479d3c663a21bfaa6c"
 
-lodash.isnull@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/lodash.isnull/-/lodash.isnull-3.0.0.tgz#fafbe59ea1dca27eed786534039dd84c2e07c56e"
-
-lodash.isnumber@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
-
-lodash.isobject@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash.isobject/-/lodash.isobject-3.0.2.tgz#3c8fb8d5b5bf4bf90ae06e14f2a530a4ed935e1d"
-
 lodash.isplainobject@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
-
-lodash.isundefined@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz#23ef3d9535565203a66cefd5b830f848911afb48"
 
 lodash.keys@^3.1.2:
   version "3.1.2"
@@ -4021,7 +3997,7 @@ lodash.keys@^3.1.2:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
-lodash.map@^4.4.0, lodash.map@^4.6.0:
+lodash.map@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
 
@@ -4033,7 +4009,7 @@ lodash.merge@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
 
-lodash.omitby@^4.5.0, lodash.omitby@^4.6.0:
+lodash.omitby@^4.5.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.omitby/-/lodash.omitby-4.6.0.tgz#5c15ff4754ad555016b53c041311e8f079204791"
 
@@ -4065,7 +4041,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@4.x.x, lodash@^4.0.0, lodash@^4.0.1, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0:
+lodash@4.x.x, lodash@^4.0.0, lodash@^4.0.1, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 


### PR DESCRIPTION
Hi again!

Was analyzing my production bundles and noticed this package is still using modular lodash pages.
They are going to be [deprecated soon](https://github.com/lodash/lodash/wiki/Roadmap) and don't play well with things like [lodash-webpack-plugin](https://www.npmjs.com/package/lodash-webpack-plugin)

Hopefully will help save a few KBs in production bundles.

Thanks!
