### PR TITLE
Removed extraneous semicolons to make jest-styled-components ^4.3.0 happy

### DIFF
--- a/src/components/Col/Col.js
+++ b/src/components/Col/Col.js
@@ -27,7 +27,7 @@ const Col = styled(props =>
     // Responsive Flexbox properties
     ${CSSProperty(props, breakpoint, 'order')}
     ${CSSProperty(props, breakpoint, 'align-self')}
-  `)};
+  `)}
 `;
 
 Col.defaultProps = {

--- a/src/components/Col/__snapshots__/Col.spec.js.snap
+++ b/src/components/Col/__snapshots__/Col.spec.js.snap
@@ -10,14 +10,14 @@ exports[`style rendering renders corrects 1`] = `
 >
   <Component
     alignSelf="auto"
-    className="sc-bdVaJa ijFKTi"
+    className="sc-bdVaJa hBAqoX"
     display="block"
     elementType="div"
     flex="0 0 auto"
     order={0}
   >
     <div
-      className="sc-bdVaJa ijFKTi"
+      className="sc-bdVaJa hBAqoX"
     />
   </Component>
 </Col>

--- a/src/components/Row/Row.js
+++ b/src/components/Row/Row.js
@@ -22,7 +22,7 @@ const Row = styled(props =>
     ${CSSProperty(props, breakpoint, 'justify-content')}
     ${CSSProperty(props, breakpoint, 'align-items')}
     ${CSSProperty(props, breakpoint, 'align-content')}
-  `)};
+  `)}
 `;
 
 Row.defaultProps = {

--- a/src/components/Row/__snapshots__/Row.spec.js.snap
+++ b/src/components/Row/__snapshots__/Row.spec.js.snap
@@ -13,7 +13,7 @@ exports[`style rendering renders corrects 1`] = `
   <Component
     alignContent="flex-start"
     alignItems="flex-start"
-    className="sc-bdVaJa hXfgcI"
+    className="sc-bdVaJa clTyma"
     display="flex"
     elementType="div"
     flexDirection="row"
@@ -21,7 +21,7 @@ exports[`style rendering renders corrects 1`] = `
     justifyContent="flex-start"
   >
     <div
-      className="sc-bdVaJa hXfgcI"
+      className="sc-bdVaJa clTyma"
     />
   </Component>
 </Row>


### PR DESCRIPTION
Hi Aaron, long time follower, first time committer!

I'm using [jest-styled-components](https://github.com/styled-components/jest-styled-components) to enable jest snapshot testing for components using styled-components.  As of 4.3.0, it seems quite pedantic about things like extraneous semicolons in the resulting stylesheet.  I think the issue with the semicolons would be similar to [this](https://github.com/styled-components/jest-styled-components/pull/41) issue over on the jest-styled-components project.

I debugged and found that `Row.js` and `Col.js` both had a couple of extraneous semicolons that would result in styles of `{;}` in the final stylesheet which caused parsing issues for jest-styled-components.

PR for your consideration, thanks.