### PR TITLE
Fix: issue with order 0 returning null

### DIFF
--- a/src/helpers/CSSProperty/CSSProperty.js
+++ b/src/helpers/CSSProperty/CSSProperty.js
@@ -18,7 +18,7 @@ export const getPropertyValue = (props, breakpoint, property) => {
         return value.toString();
       }
 
-      return props[propertySlug][breakpoint] || null;
+      return value || null;
     }
 
     if (breakpoint === sortBreakpoints(ThemeBreakpoints)[0]) {

--- a/src/helpers/CSSProperty/CSSProperty.js
+++ b/src/helpers/CSSProperty/CSSProperty.js
@@ -13,6 +13,11 @@ export const getPropertyValue = (props, breakpoint, property) => {
 
   if (has(props, `${propertySlug}`)) {
     if (isObject(props[propertySlug])) {
+      const value = props[propertySlug][breakpoint];
+      if (value === 0) {
+        return value.toString();
+      }
+
       return props[propertySlug][breakpoint] || null;
     }
 
@@ -27,7 +32,6 @@ export const getPropertyValue = (props, breakpoint, property) => {
 
 const CSSProperty = (props, breakpoint, property) => {
   const value = getPropertyValue(props, breakpoint, property);
-
   return isNull(value) ? null : css`
     ${property}: ${value};
   `;

--- a/src/helpers/CSSProperty/CSSProperty.spec.js
+++ b/src/helpers/CSSProperty/CSSProperty.spec.js
@@ -31,6 +31,11 @@ describe('getPropertyValue', () => {
     const mockProps = { alignSelf: { sm: 'center' } };
     expect(getPropertyValue(mockProps, 'lg', 'align-self')).toEqual(null);
   });
+
+  test('should generate value when it is 0 (falsy)', () => {
+    const mockProps = { order: { sm: 0 } };
+    expect(getPropertyValue(mockProps, 'sm', 'order')).toEqual('0');
+  });
 });
 
 describe('CSSProperty', () => {
@@ -47,5 +52,10 @@ describe('CSSProperty', () => {
   test('should generte css nested property', () => {
     const mockProps = { alignSelf: { sm: 'center' } };
     expect(CSSProperty(mockProps, 'sm', 'align-self').join('')).toContain('align-self: center');
+  });
+
+  test('should generte order even when 0', () => {
+    const mockProps = { order: { sm: 0 } };
+    expect(CSSProperty(mockProps, 'sm', 'order').join('')).toContain('order: 0');
   });
 });

--- a/src/helpers/CSSProperty/CSSProperty.spec.js
+++ b/src/helpers/CSSProperty/CSSProperty.spec.js
@@ -36,6 +36,11 @@ describe('getPropertyValue', () => {
     const mockProps = { order: { sm: 0 } };
     expect(getPropertyValue(mockProps, 'sm', 'order')).toEqual('0');
   });
+
+  test('should not generate value when it is null (falsy)', () => {
+    const mockProps = { order: { sm: false } };
+    expect(getPropertyValue(mockProps, 'sm', 'order')).toEqual(null);
+  });
 });
 
 describe('CSSProperty', () => {


### PR DESCRIPTION
Closes #55 

Checked to see if value was `=== 0` and if so return `"0"`