### PR TITLE
fix: add missing semicolons to display attribute

### DIFF
--- a/src/helpers/columnWidth/columnWidth.js
+++ b/src/helpers/columnWidth/columnWidth.js
@@ -11,10 +11,10 @@ export const percentage = (props, breakpoint) =>
 
 export const display = (props, breakpoint) => {
   if ((props.display && isString(props.display))) {
-    return css`display: ${props.display}`;
+    return css`display: ${props.display};`;
   }
 
-  return !has(props.display, `${breakpoint}`) ? css`display: block` : null;
+  return !has(props.display, `${breakpoint}`) ? css`display: block;` : null;
 };
 
 export const isHidden = (props, breakpoint) =>


### PR DESCRIPTION
In `src/helpers/columnWidth/columnWidth.js`, the display CSS attributes returned from `display()` is missing semicolons. When compiled, it leads to CSS errors when running the page through the W3 validator. For example, here is a CSS snippet generated by flexa that has this issue:

```css
.gpjAiT{box-sizing:border-box;display:block;padding-left:calc(2rem / 2);padding-right:calc(2rem / 2);-webkit-flex:0 0 auto;-ms-flex:0 0 auto;flex:0 0 auto;-webkit-flex-basis:100%;-ms-flex-preferred-size:100%;flex-basis:100%;max-width:100%;display:block   align-self:auto;}
```